### PR TITLE
remove set -e flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,29 +131,6 @@ $ terragrunt --version
 terragrunt v0.10.3
 ```
 
-### Environment Variables
-
-#### TGENV
-
-##### `TGENV_AUTO_INSTALL`
-
-String (Default: true)
-
-Should tgenv automatically install terragrunt if the version specified by defaults or a .terragrunt-version file is not currently installed.
-
-```console
-TGENV_AUTO_INSTALL=false terragrunt plan
-```
-
-##### `TGENV_DEBUG`
-
-Integer (Default: "")
-
-Set the debug level for TGENV.
-
-* unset/empty-string: No debug output
-* set: Bash execution tracing
-
 ## Upgrading
 ```bash
 $ git --git-dir=~/.tgenv/.git pull

--- a/libexec/tgenv-exec
+++ b/libexec/tgenv-exec
@@ -15,27 +15,8 @@
 
 set -e
 [ -n "${TGENV_DEBUG}" ] && set -x
-source "${TGENV_ROOT}/libexec/helpers"
 
-info 'Getting version from tgenv-version-name';
-TGENV_VERSION="$(tgenv-version-name)" \
-  && info "TGENV_VERSION is ${TGENV_VERSION}" \
-  || {
-    # Errors will be logged from tgenv-version name,
-    # we don't need to trouble STDERR with repeat information here
-    error_and_die 'Failed to get version from tgenv-version-name';
-  };
-export TGENV_VERSION;
-
-if [ ! -d "${TGENV_ROOT}/versions/${TGENV_VERSION}" ]; then
-  if [ "${TGENV_AUTO_INSTALL:-false}" == "true" ]; then
-    info "version '${TGENV_VERSION}' is not installed (set by $(tgenv-version-file)). Installing now as TGENV_AUTO_INSTALL==true";
-    tgenv-install;
-  else
-    error_and_die "version '${TGENV_VERSION}' was requested, but not installed and TGENV_AUTO_INSTALL is not 'true'";
-  fi;
-fi;
-
+export TGENV_VERSION="$(tgenv-version-name)"
 TG_BIN_PATH="${TGENV_ROOT}/versions/${TGENV_VERSION}/terragrunt"
 export PATH="${TG_BIN_PATH}:${PATH}"
 "${TG_BIN_PATH}" "${@}"

--- a/libexec/tgenv-list-remote
+++ b/libexec/tgenv-list-remote
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-set -e
-
 link_release="https://api.github.com/repos/gruntwork-io/terragrunt/tags?per_page=1000"
 
 # the  response header (--head) contains a link to the last page, contains the last page number and the "last" keyword to help identify

--- a/libexec/tgenv-version-name
+++ b/libexec/tgenv-version-name
@@ -30,8 +30,8 @@ version_exists() {
   [ -d "${TGENV_ROOT}/versions/${version}" ]
 }
 
-if ! version_exists "${TGENV_VERSION}"; then
-  warn_and_continue "version '${TGENV_VERSION}' is not installed (set by ${TGENV_VERSION_FILE})"
+if version_exists "${TGENV_VERSION}"; then
+  echo "${TGENV_VERSION}"
+else
+  error_and_die "version '${TGENV_VERSION}' is not installed (set by ${TGENV_VERSION_FILE})"
 fi
-
-echo "${TGENV_VERSION}"


### PR DESCRIPTION
this change was reverted by a merge with master... making it again

so removed the `set -e`
in addition, we inserted a commit we didn't have before in out version, that was on `master`. this commit caused extra prints, that broke some steps in our code. reverted it as well.