### PR TITLE
Fix delete version folder on curl fail

### DIFF
--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -74,7 +74,7 @@ if [ "$curl_status" -eq 0 ]; then
   info "Installation of terragrunt v${version} successful"
   tgenv-use "${version}"
 else
-    # make sure versions folder not exists, so we can retry installation
+    # make sure versions folder does not exist, so we can retry installation
     rm -rf "${dst_path}"
     error_and_die "Tarball download failed"
 fi


### PR DESCRIPTION
The Issue
for some reason, command tgenv-install sometimes fails on curl command, resulting in Tarball download failed.
although the operation failed, the terragrunt folder inside versions is still created, therefore causing a bug when trying to retry the tgenv-install command.

The Fix
added a check after CURL to check exit status (assuming it was not 0 when failed)
if its not 0 - remove terragrunt folder so that we can retry the command again.