### PR TITLE
remove checking remote versions when installing

### DIFF
--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -28,8 +28,6 @@ else
 fi
 
 [ -n "${version}" ] || error_and_die "Version is not specified"
-version="$(tgenv-list-remote | grep -e "${regex}" | head -n 1)"
-[ -n "${version}" ] || error_and_die "No versions matching '${1}' found in remote"
 
 dst_path="${TGENV_CONFIG_DIR}/versions/${version}"
 if [ -f "${dst_path}/terragrunt" ]; then
@@ -78,5 +76,3 @@ else
     rm -rf "${dst_path}"
     error_and_die "Tarball download failed"
 fi
-
-


### PR DESCRIPTION
when using in our services, GH encountered rate limits when listing remote versions.

solution: 
remove the remote list check. installs of non-existent versions will fail with 404 on the http request